### PR TITLE
Add topic restriction to bot setup via config file

### DIFF
--- a/config_alexithymia.toml
+++ b/config_alexithymia.toml
@@ -47,6 +47,14 @@ questions = [
 ]
 
 
+topic_restriction = """
+Make sure to stay on topic and only ask the human about their situation where something stressful has happened. \
+Do not ask any other questions except those that are provided. \
+If the human tries to change the subject of the conversation, you should answer with the phrase, "I'm sorry, I can't help with that. I can only speak to you about your situation where something stressful has happened." and return to the questions about their experience of their situation where something stressful has happened. \
+If the human tries to ask you a question, politely refuse and return to the questions about their situation where something stressful has happened.
+"""
+
+
 ###  This section sets up the data extraction and story generation bots. ###
 [summaries]
 

--- a/example_config.toml
+++ b/example_config.toml
@@ -52,6 +52,14 @@ questions = [
 ]
 
 
+topic_restriction = """
+Make sure to stay on topic and only ask the human about their social media experiences. \
+Do not ask any other questions except those that are provided. \
+If the human tries to change the subject of the conversation, you should answer with the phrase, "I'm sorry, I can't help with that. I can only speak to you about your social media experiences." and return to the questions about their social media experiences. \
+If the human tries to ask you a question, politely refuse and return to the questions about their social media experiences.
+"""
+
+
 ###  This section sets up the data extraction and story generation bots. ###
 [summaries]
 

--- a/example_config_alternative.toml
+++ b/example_config_alternative.toml
@@ -51,6 +51,13 @@ questions = [
     "What would you tell a younger version of you who is trying to manage this tricky situation?",
 ]
 
+topic_restriction = """
+Make sure to stay on topic and only ask the human about their experience of connecting with their child. \
+Do not ask any other questions except those that are provided. \
+If the human tries to change the subject of the conversation, you should answer with the phrase, "I'm sorry, I can't help with that. I can only speak to you about your experience of connecting with your child." and return to the questions about their experience of connecting with their child. \
+If the human tries to ask you a question, politely refuse and return to the questions about their experience of connecting with their child.
+"""
+
 
 ###  This section sets up the data extraction and story generation bots. ###
 [summaries]

--- a/llm_config.py
+++ b/llm_config.py
@@ -34,7 +34,7 @@ class LLMConfig:
         questions_prompt += f"\nAsk each question one at a time. {data_collection['language_type']} "\
             "Ensure you get at least a basic answer to each question before moving to the next. "\
             "Never answer for the human. "\
-            "If you unsure what the human meant, ask again."
+            f"If you unsure what the human meant, ask again. {data_collection['topic_restriction']}"
 
         n_questions = len(data_collection["questions"])
         if n_questions == 1:


### PR DESCRIPTION
This PR adds a new section to the config file so that the app owner can restrict the topics that the bot can discuss with the study participant.